### PR TITLE
Commemorative days

### DIFF
--- a/CommemorativeDays/CommemorativeDaysFunctions.js
+++ b/CommemorativeDays/CommemorativeDaysFunctions.js
@@ -1,37 +1,33 @@
 export function getDayOfWeekIndex(dayName) {
-    const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-    return daysOfWeek.indexOf(dayName);
-  }
-  
-  export function getFirstDayOfMonth(date) {
-    const year = date.getFullYear();
-    const month = date.getMonth();
-    return new Date(year, month, 1);  
-  }
-  
-  export function calculateOccurrenceDate(month, year, dayName, occurrence) {
-    const firstDay = getFirstDayOfMonth(new Date(year, month));
-    const firstDayOfWeek = firstDay.getDay();  
-  
-    const targetDayIndex = getDayOfWeekIndex(dayName);  
-    let offset = targetDayIndex - firstDayOfWeek;
+  const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  return daysOfWeek.indexOf(dayName);
+}
+
+export function getFirstDayOfMonth(date) {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  return new Date(year, month, 1);  
+}
+
+export function calculateOccurrenceDate(month, year, dayName, occurrence) {
+  const firstDay = getFirstDayOfMonth(new Date(year, month));
+  const firstDayOfWeek = firstDay.getDay();  
+
+  const targetDayIndex = getDayOfWeekIndex(dayName);  
+  let offset = targetDayIndex - firstDayOfWeek;
+  if (offset < 0) offset += 7;  
+
+  let dateOfOccurrence = new Date(year, month, 1 + offset); 
+
+  if (occurrence === 'second') {
+    dateOfOccurrence.setDate(dateOfOccurrence.getDate() + 7);  
+  } else if (occurrence === 'third') {
+    dateOfOccurrence.setDate(dateOfOccurrence.getDate() + 14);  
+  } else if (occurrence === 'last') {
+    const lastDay = new Date(year, month + 1, 0);  
+    offset = lastDay.getDay() - targetDayIndex;
     if (offset < 0) offset += 7;  
-  
-    let dateOfOccurrence = new Date(year, month, 1 + offset); 
-  
-    if (occurrence === 'second') {
-      dateOfOccurrence.setDate(dateOfOccurrence.getDate() + 7);  
-    } else if (occurrence === 'third') {
-      dateOfOccurrence.setDate(dateOfOccurrence.getDate() + 14);  
-    } else if (occurrence === 'last') {
-      const lastDay = new Date(year, month + 1, 0);  
-      offset = lastDay.getDay() - targetDayIndex;
-      if (offset < 0) offset += 7;  
-      dateOfOccurrence = new Date(lastDay.setDate(lastDay.getDate() - offset));
-    }
-  
-    return dateOfOccurrence;
+    dateOfOccurrence = new Date(lastDay.setDate(lastDay.getDate() - offset));
   }
-  
-
-
+  return dateOfOccurrence;
+}

--- a/CommemorativeDays/loadCommemorativeDays.js
+++ b/CommemorativeDays/loadCommemorativeDays.js
@@ -1,22 +1,32 @@
-import { getDayOfWeekIndex, getFirstDayOfMonth, calculateOccurrenceDate } from './CommemorativeDaysFunctions.js';
+import { calculateOccurrenceDate } from './CommemorativeDaysFunctions.js';
 
-export async function loadCommemorativeDays() {
+export let commemorativeDays = [];
+
+export async function loadCommemorativeDays(year) {
   try {
     const response = await fetch('./data/days.json');
     const data = await response.json();
 
+    commemorativeDays.length = 0;
+
     data.forEach((day) => {
-      const year = day.year || 2024;
-      const month = new Date(Date.parse(day.monthName + " 1, " + year)).getMonth(); 
+      const month = new Date(Date.parse(`${day.monthName} 1, ${year}`)).getMonth(); 
 
       const commemorativeDate = calculateOccurrenceDate(month, year, day.dayName, day.occurence);
 
-      // Will be removed later
-      console.log(`${day.name} falls on ${commemorativeDate.toDateString()}`); 
+      if (!isNaN(commemorativeDate)) {
+        commemorativeDays.push({
+          name: day.name,
+          date: commemorativeDate,
+          descriptionURL: day.descriptionURL,
+        });
+        
+        console.log(`${day.name} in ${year} falls on ${commemorativeDate.toDateString()}`);
+      } else {
+        console.error(`Invalid commemorative date for ${day.name}`);
+      }
     });
   } catch (error) {
     console.error('Error loading JSON data:', error);
   }
 }
-
-

--- a/calendar/createAndRenderDaysInMonth.js
+++ b/calendar/createAndRenderDaysInMonth.js
@@ -1,16 +1,56 @@
+import { commemorativeDays } from "../CommemorativeDays/loadCommemorativeDays.js";
 import { calendarContainerEl } from "../queries.js";
 import { calendarConfig } from "./calendarConfig.js";
 
-function createDayMonth(day) {
+function isCommemorativeDay(day, date, event) {
+  const eventDate = new Date(event.date);
+  return (
+    eventDate.getDate() === day &&
+    eventDate.getMonth() === date.getMonth() &&
+    eventDate.getFullYear() === date.getFullYear()
+  );
+}
+
+function createEventLabel(event) {
+  const eventLabel = document.createElement("span");
+  eventLabel.textContent = ` - ${event.name}`;
+  eventLabel.classList.add("commemorative-event");
+  return eventLabel;
+}
+
+function createDayMonth(day, date) {
   const dayElement = document.createElement("div");
   dayElement.textContent = day;
   dayElement.classList.add("calendar-day");
+
+  commemorativeDays.forEach((event) => {
+    if (isCommemorativeDay(day, date, event)) {
+      dayElement.appendChild(createEventLabel(event));
+    }
+  });
+
   return dayElement;
 }
 
+function createEmptyDayElement() {
+  const emptyDay = document.createElement("div");
+  emptyDay.classList.add("calendar-day", "empty");
+  return emptyDay;
+}
+
 export function renderDaysInMonth(date) {
+  calendarContainerEl.innerHTML = "";
+
   const daysInMonth = calendarConfig.getDaysInMonth(date);
+  const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+  const firstDayOfWeek = firstDay.getDay();
+
+  const emptyDaysCount = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1;
+  for (let i = 0; i < emptyDaysCount; i++) {
+    calendarContainerEl.appendChild(createEmptyDayElement());
+  }
+
   for (let day = 1; day <= daysInMonth; day++) {
-    calendarContainerEl.append(createDayMonth(day));
+    calendarContainerEl.append(createDayMonth(day, date));
   }
 }

--- a/calendar/createAndRenderDaysInMonth.js
+++ b/calendar/createAndRenderDaysInMonth.js
@@ -1,6 +1,7 @@
 import { commemorativeDays } from "../CommemorativeDays/loadCommemorativeDays.js";
 import { calendarContainerEl } from "../queries.js";
 import { calendarConfig } from "./calendarConfig.js";
+import { renderEmptyDays } from "./renderEmptyDays.js"; // Import the function
 
 function isCommemorativeDay(day, date, event) {
   const eventDate = new Date(event.date);
@@ -32,23 +33,12 @@ function createDayMonth(day, date) {
   return dayElement;
 }
 
-function createEmptyDayElement() {
-  const emptyDay = document.createElement("div");
-  emptyDay.classList.add("calendar-day", "empty");
-  return emptyDay;
-}
-
 export function renderDaysInMonth(date) {
   calendarContainerEl.innerHTML = "";
 
-  const daysInMonth = calendarConfig.getDaysInMonth(date);
-  const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
-  const firstDayOfWeek = firstDay.getDay();
+  renderEmptyDays(date);
 
-  const emptyDaysCount = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1;
-  for (let i = 0; i < emptyDaysCount; i++) {
-    calendarContainerEl.appendChild(createEmptyDayElement());
-  }
+  const daysInMonth = calendarConfig.getDaysInMonth(date);
 
   for (let day = 1; day <= daysInMonth; day++) {
     calendarContainerEl.append(createDayMonth(day, date));

--- a/commemorative_days.ics
+++ b/commemorative_days.ics
@@ -1,0 +1,389 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Commemorative Days Calendar//NONSGML v1.0//EN
+BEGIN:VEVENT
+DTSTAMP:20201012T230000Z
+DTSTART;VALUE=DATE:20201013
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20200508T230000Z
+DTSTART;VALUE=DATE:20200509
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20200904T230000Z
+DTSTART;VALUE=DATE:20200905
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20200918T230000Z
+DTSTART;VALUE=DATE:20200919
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20201030T000000Z
+DTSTART;VALUE=DATE:20201030
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20211011T230000Z
+DTSTART;VALUE=DATE:20211012
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20210507T230000Z
+DTSTART;VALUE=DATE:20210508
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20210903T230000Z
+DTSTART;VALUE=DATE:20210904
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20210917T230000Z
+DTSTART;VALUE=DATE:20210918
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20211028T230000Z
+DTSTART;VALUE=DATE:20211029
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20221010T230000Z
+DTSTART;VALUE=DATE:20221011
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20220513T230000Z
+DTSTART;VALUE=DATE:20220514
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20220902T230000Z
+DTSTART;VALUE=DATE:20220903
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20220916T230000Z
+DTSTART;VALUE=DATE:20220917
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20221027T230000Z
+DTSTART;VALUE=DATE:20221028
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20231009T230000Z
+DTSTART;VALUE=DATE:20231010
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20230512T230000Z
+DTSTART;VALUE=DATE:20230513
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20230901T230000Z
+DTSTART;VALUE=DATE:20230902
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20230915T230000Z
+DTSTART;VALUE=DATE:20230916
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20231026T230000Z
+DTSTART;VALUE=DATE:20231027
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20241007T230000Z
+DTSTART;VALUE=DATE:20241008
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20240510T230000Z
+DTSTART;VALUE=DATE:20240511
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20240906T230000Z
+DTSTART;VALUE=DATE:20240907
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20240920T230000Z
+DTSTART;VALUE=DATE:20240921
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20241024T230000Z
+DTSTART;VALUE=DATE:20241025
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20251013T230000Z
+DTSTART;VALUE=DATE:20251014
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20250509T230000Z
+DTSTART;VALUE=DATE:20250510
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20250905T230000Z
+DTSTART;VALUE=DATE:20250906
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20250919T230000Z
+DTSTART;VALUE=DATE:20250920
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20251031T000000Z
+DTSTART;VALUE=DATE:20251031
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20261012T230000Z
+DTSTART;VALUE=DATE:20261013
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20260508T230000Z
+DTSTART;VALUE=DATE:20260509
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20260904T230000Z
+DTSTART;VALUE=DATE:20260905
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20260918T230000Z
+DTSTART;VALUE=DATE:20260919
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20261030T000000Z
+DTSTART;VALUE=DATE:20261030
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20271011T230000Z
+DTSTART;VALUE=DATE:20271012
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20270507T230000Z
+DTSTART;VALUE=DATE:20270508
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20270903T230000Z
+DTSTART;VALUE=DATE:20270904
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20270917T230000Z
+DTSTART;VALUE=DATE:20270918
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20271028T230000Z
+DTSTART;VALUE=DATE:20271029
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20281009T230000Z
+DTSTART;VALUE=DATE:20281010
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20280512T230000Z
+DTSTART;VALUE=DATE:20280513
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20280901T230000Z
+DTSTART;VALUE=DATE:20280902
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20280915T230000Z
+DTSTART;VALUE=DATE:20280916
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20281026T230000Z
+DTSTART;VALUE=DATE:20281027
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20291008T230000Z
+DTSTART;VALUE=DATE:20291009
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20290511T230000Z
+DTSTART;VALUE=DATE:20290512
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20290831T230000Z
+DTSTART;VALUE=DATE:20290901
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20290914T230000Z
+DTSTART;VALUE=DATE:20290915
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20291025T230000Z
+DTSTART;VALUE=DATE:20291026
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20301007T230000Z
+DTSTART;VALUE=DATE:20301008
+SUMMARY:Ada Lovelace Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/ada.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20300510T230000Z
+DTSTART;VALUE=DATE:20300511
+SUMMARY:International Binturong Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20300906T230000Z
+DTSTART;VALUE=DATE:20300907
+SUMMARY:International Vulture Awareness Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/vultures.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20300920T230000Z
+DTSTART;VALUE=DATE:20300921
+SUMMARY:International Red Panda Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20301024T230000Z
+DTSTART;VALUE=DATE:20301025
+SUMMARY:World Lemur Day
+DESCRIPTION:More info at https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+URL:https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt
+END:VEVENT
+END:VCALENDAR

--- a/events/jumpHandler.js
+++ b/events/jumpHandler.js
@@ -1,11 +1,16 @@
 import { calendarContainerEl, monthSelect, yearSelect } from "../queries.js";
 import { displayCalendar } from "../calendar/displayCalendar.js";
 import { calendarConfig } from "../calendar/calendarConfig.js";
-
-export function jumpHandler() {
+import { loadCommemorativeDays } from "../CommemorativeDays/loadCommemorativeDays.js"; 
+export async function jumpHandler() {
   calendarContainerEl.innerHTML = "";
-  const selectedMonth = parseInt(monthSelect.value);
-  const selectedYear = parseInt(yearSelect.value);
-  calendarConfig.currentDate = new Date(selectedYear, selectedMonth, 1); // Update the current date
+
+  const selectedMonth = parseInt(monthSelect.value, 10); 
+  const selectedYear = parseInt(yearSelect.value, 10); 
+
+  calendarConfig.currentDate = new Date(selectedYear, selectedMonth, 1);
+
+  await loadCommemorativeDays(selectedYear);
+
   displayCalendar(calendarConfig.currentDate);
 }

--- a/events/nextMonthHandler.js
+++ b/events/nextMonthHandler.js
@@ -1,11 +1,16 @@
 import { calendarConfig } from "../calendar/calendarConfig.js";
 import { calendarContainerEl } from "../queries.js";
 import { displayCalendar } from "../calendar/displayCalendar.js";
+import { loadCommemorativeDays } from "../CommemorativeDays/loadCommemorativeDays.js"; 
 
-export function nextMonthHandler() {
+
+export async function nextMonthHandler() {
   calendarContainerEl.innerHTML = "";
   calendarConfig.currentDate.setMonth(
     calendarConfig.currentDate.getMonth() + 1
   );
+
+  await loadCommemorativeDays(calendarConfig.currentDate.getFullYear());
+  
   displayCalendar(calendarConfig.currentDate);
 }

--- a/events/prevMonthHandler.js
+++ b/events/prevMonthHandler.js
@@ -1,10 +1,15 @@
 import { calendarConfig } from "../calendar/calendarConfig.js";
 import { displayCalendar } from "../calendar/displayCalendar.js";
 import { calendarContainerEl } from "../queries.js";
-export function prevMonthHandler() {
+import { loadCommemorativeDays } from "../CommemorativeDays/loadCommemorativeDays.js"; 
+
+export async function prevMonthHandler() {
   calendarContainerEl.innerHTML = "";
   calendarConfig.currentDate.setMonth(
     calendarConfig.currentDate.getMonth() - 1
   );
+  
+  await loadCommemorativeDays(calendarConfig.currentDate.getFullYear());
+
   displayCalendar(calendarConfig.currentDate);
 }

--- a/generateICal.js
+++ b/generateICal.js
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+import { calculateOccurrenceDate } from './CommemorativeDays/CommemorativeDaysFunctions.js';
+
+const DAYS_JSON_PATH = './data/days.json';
+
+//Might be changed
+async function loadCommemorativeDays() {
+  try {
+    const data = JSON.parse(fs.readFileSync(DAYS_JSON_PATH, 'utf8'));
+    return data;
+  } catch (error) {
+    console.error('Error loading JSON data:', error);
+    process.exit(1);
+  }
+}
+
+function formatDateToICal(date) {
+  return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+function createICalEvent(event, date) {
+  const formattedDate = formatDateToICal(date);
+  return `BEGIN:VEVENT
+DTSTAMP:${formattedDate}
+DTSTART;VALUE=DATE:${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}
+SUMMARY:${event.name}
+DESCRIPTION:More info at ${event.descriptionURL}
+URL:${event.descriptionURL}
+END:VEVENT`;
+}
+
+async function generateICal() {
+  const events = await loadCommemorativeDays();
+  let icalData = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Commemorative Days Calendar//NONSGML v1.0//EN`;
+
+  for (let year = 2020; year <= 2030; year++) {
+    events.forEach((event) => {
+      const month = new Date(Date.parse(`${event.monthName} 1, ${year}`)).getMonth();
+      const date = calculateOccurrenceDate(month, year, event.dayName, event.occurence);
+
+      if (date instanceof Date && !isNaN(date.getTime())) {
+        icalData += '\n' + createICalEvent(event, date);
+      } else {
+        console.error(`Invalid date for ${event.name} in ${year}`);
+      }
+    });
+  }
+
+  icalData += `\nEND:VCALENDAR`;
+
+  const filePath = path.join(process.cwd(), 'commemorative_days.ics');
+
+  fs.writeFileSync(filePath, icalData, 'utf8');
+  console.log(`ICS file successfully generated: ${filePath}`);
+}
+
+generateICal();

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "devDependencies": {
     "@babel/core": "^7.26.8",
     "@babel/preset-env": "^7.26.8",

--- a/script.js
+++ b/script.js
@@ -2,14 +2,13 @@ import { calendarConfig } from "./calendar/calendarConfig.js";
 import { displayCalendar } from "./calendar/displayCalendar.js";
 import { eventHandlers } from "./events/events.js";
 import { renderDropDowns } from "./jump/renderDropDown.js";
-import {loadCommemorativeDays} from "./CommemorativeDays/loadCommemorativeDays.js";
+import { loadCommemorativeDays } from "./CommemorativeDays/loadCommemorativeDays.js";
 
-function main() {
-  displayCalendar(calendarConfig.currentDate);
-  eventHandlers();
-  renderDropDowns();
-  loadCommemorativeDays();
+async function main() {
+  const currentYear = new Date().getFullYear();
+  await loadCommemorativeDays(currentYear);  
+  displayCalendar(calendarConfig.currentDate);  
+  eventHandlers();  
+  renderDropDowns();  
 }
 window.onload = main;
-
-

--- a/style.css
+++ b/style.css
@@ -38,3 +38,12 @@ body {
     background-color: #f9f9f9;
     border: none;
   }
+  .commemorative-event {
+    font-size: 0.85em;
+    font-weight: bold;
+    color: #d9534f; 
+    padding: 2px 6px;
+    margin-left: 5px;
+    display: inline-block;
+  }
+  

--- a/tests/calculateOccurrenceDate.test.js
+++ b/tests/calculateOccurrenceDate.test.js
@@ -1,0 +1,13 @@
+import { calculateOccurrenceDate } from "../CommemorativeDays/CommemorativeDaysFunctions.js";
+
+describe('calculateOccurrenceDate', () => {
+    test('should return the correct date for the first occurrence of a weekday', () => {
+      expect(calculateOccurrenceDate(4, 2025, 'Monday', 'first').getDate()).toBe(5);
+      expect(calculateOccurrenceDate(9, 2026, 'Thursday', 'first').getDate()).toBe(1);
+    });
+  
+    test('should return the correct date for the last occurrence of a weekday', () => {
+      expect(calculateOccurrenceDate(4, 2025, 'Monday', 'last').getDate()).toBe(26);
+      expect(calculateOccurrenceDate(9, 2026, 'Thursday', 'last').getDate()).toBe(29);
+    });
+  });

--- a/tests/getDayOfWeekIndex.test.js
+++ b/tests/getDayOfWeekIndex.test.js
@@ -1,0 +1,13 @@
+import { getDayOfWeekIndex } from "../CommemorativeDays/CommemorativeDaysFunctions.js";
+
+describe('getDayOfWeekIndex', () => {
+  test('should return correct index for a valid day name', () => {
+    expect(getDayOfWeekIndex('Monday')).toBe(1);
+    expect(getDayOfWeekIndex('Thursday')).toBe(4);
+  });
+
+  test('should return -1 for an invalid day name', () => {
+    expect(getDayOfWeekIndex('Funday')).toBe(-1);
+    expect(getDayOfWeekIndex('')).toBe(-1);
+  });
+});

--- a/tests/getFirstDayOfMonth.test.js
+++ b/tests/getFirstDayOfMonth.test.js
@@ -1,0 +1,14 @@
+import { getFirstDayOfMonth } from "../CommemorativeDays/CommemorativeDaysFunctions.js";
+
+describe('getFirstDayOfMonth', () => {
+    test('should return the first day of the month for a given date', () => {
+      expect(getFirstDayOfMonth(new Date(2025, 4, 15)).getDate()).toBe(1);
+      expect(getFirstDayOfMonth(new Date(2026, 10, 22)).getDate()).toBe(1);
+    });
+  
+    test('should return a Date object with the correct month and year', () => {
+      const firstDay = getFirstDayOfMonth(new Date(2025, 6, 20));
+      expect(firstDay.getFullYear()).toBe(2025);
+      expect(firstDay.getMonth()).toBe(6);
+    });
+  });


### PR DESCRIPTION
Updated createAndRenderDaysInMonth to display commemorative days.

Next Step: Updating "Next Month" and "Previous Month" navigation to  handle year transitions (e.g., December 2025 → January 2026).